### PR TITLE
Fix typeError exception when using keycloak with non memory store

### DIFF
--- a/src/KeycloakMultiRealm.js
+++ b/src/KeycloakMultiRealm.js
@@ -11,7 +11,14 @@ const PostAuth = require(path.join(process.cwd(), './node_modules/keycloak-conne
 const GrantAttacher = require(path.join(process.cwd(), './node_modules/keycloak-connect/middleware/grant-attacher'));
 const Protect = require(path.join(process.cwd(), './node_modules/keycloak-connect/middleware/protect'));
 
-const cache = new NodeCache();
+/**
+ * We do not use clones because NodeCache throws exception
+ * if the Keycloak is initiated with a non memory store(like redis-store).
+ * Whenever keycloak is initialised with redis-store, the keycloak object contains
+ * some deeply nested http connection objects, NodeCache fails because clone fails,
+ * hence useClones is set to false.
+ */
+const cache = new NodeCache({'useClones': false});
 
 const defaultOptions = {
   'admin': '/',

--- a/src/KeycloakMultiRealm.spec.js
+++ b/src/KeycloakMultiRealm.spec.js
@@ -51,7 +51,7 @@ describe('KeycloakMultiRealm', () => {
 
     keycloakMultiRealm = new KeycloakMultiRealm(config, keycloakConfig);
 
-    cache = new NodeCache();
+    cache = new NodeCache({'useClones': false});
     cache.get = jest.fn();
     cache.get.mockClear();
     cache.set.mockClear();


### PR DESCRIPTION
Fixing this issue: https://github.com/devsu/keycloak-nodejs-multirealm/issues/3

As suggested, I have passed NodeCache config param to set useClones as false.