### PR TITLE
Add accessDenied to keycloakObject to enable overriding

### DIFF
--- a/src/KeycloakMultiRealm.js
+++ b/src/KeycloakMultiRealm.js
@@ -110,6 +110,7 @@ module.exports = class {
     keycloakObject = new Keycloak(this.config, keycloakConfig);
     keycloakObject.authenticated = this.authenticated;
     keycloakObject.deauthenticated = this.deauthenticated;
+    keycloakObject.accessDenied = this.accessDenied;
     cache.set(realm, keycloakObject);
     return keycloakObject;
   }


### PR DESCRIPTION
By adding the line below you enable the user to override the keycloak accessDenied method.